### PR TITLE
feat: 글 상세보기 시 최근에 봤던 글을 redis 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,12 @@ dependencies {
     // spring mail
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+    //spring redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ll/demo/article/controller/ArticleController.java
+++ b/src/main/java/com/ll/demo/article/controller/ArticleController.java
@@ -51,7 +51,6 @@ public class ArticleController {
     private final TagService tagService;
     private final ImageService imageService;
     private final Rq rq;
-    private final RedisTemplate<String, String> redisTemplate;
 
     //전체 글 조회
     @GetMapping("")
@@ -64,27 +63,15 @@ public class ArticleController {
     //단일 글 조회
     @GetMapping("/detail/{id}")
     @Operation(summary = "단일 글 조회", description = "단일 글 조회 시 사용하는 API")
-    public GlobalResponse showArticle(@PathVariable("id") Long id) throws JsonProcessingException {
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
-        ListOperations<String, String> listOperations = redisTemplate.opsForList();
-
-        // Redis에서 글 내용을 조회
-        List<String> cachedArticleJson = listOperations.range(id.toString(), 0, -1);
-        Article article;
-        //Redis에 없거나 Redis가 비어 있는 경우 key:id, value:article의 JSON 저장
-        if (cachedArticleJson == null || cachedArticleJson.isEmpty()) {
-            article = articleService.getArticleById(id);
-            String articleJson = objectMapper.writeValueAsString(article);
-            listOperations.leftPush(id.toString(), articleJson);
-        } else {
-            // Redis에 글이 있으면, 첫 번째 JSON 문자열을 Article 객체로 역직렬화합니다.
-            article = objectMapper.readValue(cachedArticleJson.get(0), Article.class);
-            System.out.println("여기 지나감 ㅎㅎㅎㅎㅎ");
-        }
-
+    public GlobalResponse showArticle(@PathVariable("id") Long id)  {
+        Article article = articleService.getArticleById(id);
         ArticleDetailResponseDto articleDetailResponseDto = new ArticleDetailResponseDto(article);
-        if (rq.isLoggedIn() && articleService.getLikeByArticleIdAndMemberId(article.getId(), memberService.findByUsername(rq.getUser().getUsername()).getId()) != null) {
+        Long memberId = memberService.findByUsername(rq.getUser().getUsername()).getId();
+
+        if(rq.isLoggedIn()){
+            articleService.saveRecentReadPosts(memberId, id);
+        }
+        if (rq.isLoggedIn() && articleService.getLikeByArticleIdAndMemberId(article.getId(), memberId) != null) {
             articleDetailResponseDto.setLikeValue(true);
         } else {
             articleDetailResponseDto.setLikeValue(false);

--- a/src/main/java/com/ll/demo/article/dto/ArticleDetailResponseDto.java
+++ b/src/main/java/com/ll/demo/article/dto/ArticleDetailResponseDto.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 @Getter
 @Setter
 public class ArticleDetailResponseDto {
+    private Long id;
     private String content;
     private String username;
     private boolean paid;
@@ -26,7 +27,13 @@ public class ArticleDetailResponseDto {
     private boolean likeValue;
     private List<ListCommentResponse> listCommentResponses;
 
+    // Jackson 역직렬화를 위한 기본 생성자 추가
+    public ArticleDetailResponseDto() {
+        super();
+    }
+
     public ArticleDetailResponseDto(Article article) {
+        this.id = article.getId();
         this.content = article.getContent();
         this.username = article.getMember().getUsername();
         this.paid = article.isPaid();

--- a/src/main/java/com/ll/demo/article/entity/Article.java
+++ b/src/main/java/com/ll/demo/article/entity/Article.java
@@ -1,6 +1,8 @@
 package com.ll.demo.article.entity;
 
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.ll.demo.comment.entity.Comment;
 import com.ll.demo.global.entity.BaseEntity;
 import com.ll.demo.member.entity.Member;
@@ -19,6 +21,9 @@ import java.util.Set;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
+@JsonIdentityInfo(
+        generator = ObjectIdGenerators.PropertyGenerator.class,
+        property = "id")
 public class Article extends BaseEntity {
 
     @Id

--- a/src/main/java/com/ll/demo/article/entity/ArticleTag.java
+++ b/src/main/java/com/ll/demo/article/entity/ArticleTag.java
@@ -1,5 +1,7 @@
 package com.ll.demo.article.entity;
 
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -9,6 +11,9 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@JsonIdentityInfo(
+        generator = ObjectIdGenerators.PropertyGenerator.class,
+        property = "id")
 public class ArticleTag {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ll/demo/article/service/ArticleService.java
+++ b/src/main/java/com/ll/demo/article/service/ArticleService.java
@@ -197,7 +197,7 @@ public class ArticleService {
         Optional<Article> opArticle = articleRepository.findById(articleId);
         if (opArticle.isPresent()) {
             ArticleDetailResponseDto articleDetailResponseDto = new ArticleDetailResponseDto(opArticle.get());
-            String key = "userIdx::"+ userId;
+            String key = "userId::"+ userId;
             listOperations.leftPush(key, articleDetailResponseDto);
             redisTemplate.expireAt(key, Instant.now().plus(7, ChronoUnit.DAYS)); // 유효기간 TTL 일주일 설정
         }
@@ -208,15 +208,16 @@ public class ArticleService {
     @Transactional
     public ArticleDetailResponseDto findRecentArticle(Long userId, Long articleId) {
         ListOperations<String, Object> listOperations = redisTemplate.opsForList();
-        String key = "userIdx::" + userId;
+        String key = "userId::" + userId;
         Long size = listOperations.size(key);
         List<Object> results = size > 0 ? listOperations.range(key, 0, size) : Collections.emptyList();
+        System.out.println(results);
         return results.stream()
                 .map(this::convertMapToArticleDetailResponseDto)
                 .filter(Objects::nonNull) // null이 아닌 객체만 필터링
                 .filter(dto -> articleId.equals(dto.getId()))
                 .findFirst()
-                .orElse(null); // 일치하는 객체가 없으면 null을 반환합니다.
+                .orElse(null); // 일치하는 객체가 없으면 null을 반환
     }
 
     private ArticleDetailResponseDto convertMapToArticleDetailResponseDto(Object o) {

--- a/src/main/java/com/ll/demo/global/config/redis/RedisConfig.java
+++ b/src/main/java/com/ll/demo/global/config/redis/RedisConfig.java
@@ -1,5 +1,9 @@
 package com.ll.demo.global.config.redis;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -7,6 +11,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -24,10 +29,9 @@ public class RedisConfig {
     @Bean
     public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory){
         RedisTemplate<String,Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new StringRedisSerializer());
-        redisTemplate.setDefaultSerializer(RedisSerializer.string());
-        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper()));
         return redisTemplate;
     }
     @Bean
@@ -35,5 +39,13 @@ public class RedisConfig {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(connectionFactory);
         return container;
+    }
+
+    // jackson LocalDateTime mapper
+    @Bean public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // timestamp 형식 안따르도록 설정
+        mapper.registerModules(new JavaTimeModule(), new Jdk8Module()); // LocalDateTime 매핑을 위해 모듈 활성화
+        return mapper;
     }
 }

--- a/src/main/java/com/ll/demo/global/config/redis/RedisConfig.java
+++ b/src/main/java/com/ll/demo/global/config/redis/RedisConfig.java
@@ -27,13 +27,14 @@ public class RedisConfig {
         return new LettuceConnectionFactory(redisHost, redisPort);
     }
     @Bean
-    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory){
-        RedisTemplate<String,Object> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory());
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper()));
         return redisTemplate;
     }
+
     @Bean
     public RedisMessageListenerContainer redisMessageListener(RedisConnectionFactory connectionFactory){
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();

--- a/src/main/java/com/ll/demo/global/config/redis/RedisConfig.java
+++ b/src/main/java/com/ll/demo/global/config/redis/RedisConfig.java
@@ -1,0 +1,39 @@
+package com.ll.demo.global.config.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory){
+        RedisTemplate<String,Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setDefaultSerializer(RedisSerializer.string());
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        return redisTemplate;
+    }
+    @Bean
+    public RedisMessageListenerContainer redisMessageListener(RedisConnectionFactory connectionFactory){
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        return container;
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,23 +1,23 @@
 server:
   shutdown: graceful
-  port: ${port}
+  port: 8090
 spring:
   servlet:
     multipart:
-      max-file-size: 5MB
-      max-request-size: 5MB
+      max-file-size: 50MB
+      max-request-size: 50MB
   datasource:
-    url: ${database.url}
-    username: ${database.username}
-    password: ${database.password}
+    url: jdbc:mysql://172.17.0.1:3306/imgforest_prod
+    username: userlocal
+    password: 1234
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
   cloud:
     aws:
-      accessKey: ON_SECRET
-      secretKey: ON_SECRET
+      ${spring.profiles.include}.accessKey: ${cloud.aws.accessKey}
+      ${spring.profiles.include}.secretKey: ${cloud.aws.secretKey}
       regionName: kr-standard
       bucketName: img-forest-image-prod
   data:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -20,6 +20,10 @@ spring:
       secretKey: ON_SECRET
       regionName: kr-standard
       bucketName: img-forest-image-prod
+  data:
+    redis:
+      host: "172.17.0.1"
+      port: 6379
 logging:
   level:
     com.ll.medium: INFO

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,7 +38,10 @@ spring:
       regionName: kr-standard
       endpoint: https://kr.object.ncloudstorage.com
       bucketName: img-forest-image
-
+  data:
+    redis:
+      host: "${custom.dev.cookieDomain}"
+      port: 6379
 logging:
   level:
     com.ll.medium: DEBUG
@@ -46,6 +49,7 @@ logging:
     org.hibernate.orm.jdbc.bind: TRACE
     org.hibernate.orm.jdbc.extract: TRACE
     org.springframework.transaction.interceptor: TRACE
+
 custom:
   dev:
     cookieDomain: localhost


### PR DESCRIPTION
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성 -->
글 상세보기 시 최근에 봤던 글을 redis 추가하여 DB 호출을 낮춤
## PR 작업 내용
1. redis 추가
2. 로그인 후 단일 글 확인 시 redis에 저장된게 없을 시 DB에서 가져오고 redis에 Key:userId ,value: article 객체 저장
3. 로그인 후 단일 글 확인 시 redis에 저장된 articleID와 조회한 글 id가 같다면 redis에서 article 정보 가져옴
4. redis에 저장 시 object로 저장하고 불러올 때 Map 형태의 객체를 Dto객체로 변환하여 가져옴

## 작업 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 리팩토링
- [x] 문서 추가, 수정
- [ ] 빌드, 패키지 매니저 수정
- [ ] 파일 / 폴더명 수정
- [ ] 파일 / 폴더명 삭제
- [ ] 주석 추가 및 수정
- [ ] 사용자 UI 및 디자인 변경
- [ ] 기타 코드 내용에 영향을 주지 않는 변경사항(인덴트 등)

## 참고사항
<!-- 관련 이슈, 추가 내용 등 작성 -->
